### PR TITLE
[app] add webhook-tester service

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,5 +46,8 @@ SMPP__GATEWAY__API_BASE_URL=http://backend:3000/api/3rdparty/v1
 ## SMTP
 EMAIL_TO_SMS__GATEWAY__API_BASE_URL=http://backend:3000/api/3rdparty/v1
 
+# Webhook Tester
+WEBHOOK__REDIS_DSN=redis://redis:6379/1
+
 # Monitoring stack
 PROMETHEUS__IP_ALLOWLIST=127.0.0.1/32

--- a/compose.app.yml
+++ b/compose.app.yml
@@ -293,6 +293,62 @@ services:
         order: start-first
         monitor: 15s
 
+  webhook-tester:
+    image: ghcr.io/tarampampam/webhook-tester:2
+    environment:
+      - TZ=${TIMEZONE:-UTC}
+      - STORAGE_DRIVER=redis
+      - PUBSUB_DRIVER=redis
+      - REDIS_DSN=${WEBHOOK__REDIS_DSN:-redis://redis:6379/1}
+      - AUTO_CREATE_SESSIONS=true
+      - MAX_REQUEST_BODY_SIZE=10240
+      - SESSION_TTL=24h
+      - LOG_FORMAT=json
+    networks:
+      - internal
+      - public
+    deploy:
+      labels:
+        traefik.enable: "true"
+        traefik.swarm.network: "public"
+
+        traefik.http.routers.webhook-tester.rule: "Host(`webhook.${ROOT_DOMAIN}`)"
+        traefik.http.routers.webhook-tester.entrypoints: "https"
+        traefik.http.routers.webhook-tester.tls.certresolver: "le"
+        traefik.http.routers.webhook-tester.middlewares: "webhook-general-ratelimit"
+        traefik.http.services.webhook-tester.loadbalancer.server.port: "8080"
+
+        traefik.http.routers.webhook-tester-capture.rule: "Host(`webhook.${ROOT_DOMAIN}`) && PathRegexp(`^/[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}`)"
+        traefik.http.routers.webhook-tester-capture.entrypoints: "https"
+        traefik.http.routers.webhook-tester-capture.tls.certresolver: "le"
+        traefik.http.routers.webhook-tester-capture.middlewares: "webhook-capture-ratelimit"
+
+        traefik.http.middlewares.webhook-general-ratelimit.ratelimit.average: "10"
+        traefik.http.middlewares.webhook-general-ratelimit.ratelimit.period: "1s"
+        traefik.http.middlewares.webhook-general-ratelimit.ratelimit.burst: "20"
+        traefik.http.middlewares.webhook-general-ratelimit.ratelimit.sourcecriterion.ipstrategy.depth: "1"
+
+        traefik.http.middlewares.webhook-capture-ratelimit.ratelimit.average: "5"
+        traefik.http.middlewares.webhook-capture-ratelimit.ratelimit.period: "1s"
+        traefik.http.middlewares.webhook-capture-ratelimit.ratelimit.burst: "10"
+        traefik.http.middlewares.webhook-capture-ratelimit.ratelimit.sourcecriterion.ipstrategy.depth: "1"
+      replicas: 1
+      resources:
+        reservations:
+          memory: 32M
+        limits:
+          memory: 64M
+      restart_policy:
+        condition: any
+        window: 15s
+      update_config:
+        order: start-first
+        monitor: 15s
+        failure_action: rollback
+      rollback_config:
+        order: start-first
+        monitor: 15s
+
 configs:
   backend_config-yml:
     name: app_backend_config-yml_${STACK_VERSION:-0}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new webhook testing service to the app stack.
  * Exposed a secure web endpoint for the tester at `webhook.<domain>`, with TLS enabled.
  * Added support for Redis-backed storage to improve webhook capture and session handling.
  * Included request rate limiting and a special capture route to better manage incoming webhook traffic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->